### PR TITLE
Make standalone RPC more reliable and fix nameko shell to work correctly

### DIFF
--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -94,6 +94,7 @@ def main(args):
         broker_from
     )
 
+    # ctx will be initialized via this lambda func after shell runner start
     ctx_func = lambda: {'n': make_nameko_helper(config)}
     runner = ShellRunner(banner, ctx_func)
     runner.start_shell(name=args.interface)

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -6,30 +6,28 @@ import yaml
 
 import nameko.cli.code as code
 from nameko.constants import AMQP_URI_CONFIG_KEY
-from nameko.standalone.events import event_dispatcher
-from nameko.standalone.rpc import ClusterRpcProxy
 
 from .commands import Shell
 
 
 class ShellRunner(object):
 
-    def __init__(self, banner, local):
+    def __init__(self, banner, get_local):
         self.banner = banner
-        self.local = local
+        self.local = get_local
 
     def bpython(self):
         import bpython  # pylint: disable=E0401
-        bpython.embed(banner=self.banner, locals_=self.local)
+        bpython.embed(banner=self.banner, locals_=self.local())
 
     def ipython(self):
         from IPython import embed  # pylint: disable=E0401
-        embed(banner1=self.banner, user_ns=self.local)
+        embed(banner1=self.banner, user_ns=self.local())
 
     def plain(self):
         code.interact(
             banner=self.banner,
-            local=self.local,
+            local=self.local(),
             raise_expections=not sys.stdin.isatty()
         )
 
@@ -44,7 +42,7 @@ class ShellRunner(object):
         startup = os.environ.get('PYTHONSTARTUP')
         if startup and os.path.isfile(startup):
             with open(startup, 'r') as f:
-                eval(compile(f.read(), startup, 'exec'), self.local)
+                eval(compile(f.read(), startup, 'exec'), self.local())
             del os.environ['PYTHONSTARTUP']
 
         for name in available_shells:
@@ -69,8 +67,10 @@ Usage:
 
     >>> n.dispatch_event('service', 'event_type', 'event_data')
 """
+    from nameko.standalone.rpc import ClusterRpcProxy
     proxy = ClusterRpcProxy(config)
     module.rpc = proxy.start()
+    from nameko.standalone.events import event_dispatcher
     module.dispatch_event = event_dispatcher(config)
     module.config = config
     module.disconnect = proxy.stop
@@ -94,8 +94,6 @@ def main(args):
         broker_from
     )
 
-    ctx = {}
-    ctx['n'] = make_nameko_helper(config)
-
-    runner = ShellRunner(banner, ctx)
+    ctx_func = lambda: {'n': make_nameko_helper(config)}
+    runner = ShellRunner(banner, ctx_func)
     runner.start_shell(name=args.interface)

--- a/nameko/cli/shell.py
+++ b/nameko/cli/shell.py
@@ -78,7 +78,7 @@ Usage:
 
 
 def main(args):
-
+    sys.path.append('.')  # Add current working directory to System path
     if args.config:
         with open(args.config) as fle:
             config = yaml.unsafe_load(fle)

--- a/nameko/standalone/events.py
+++ b/nameko/standalone/events.py
@@ -12,7 +12,8 @@ def get_event_exchange(service_name):
     """
     exchange_name = "{}.events".format(service_name)
     exchange = Exchange(
-        exchange_name, type='topic', durable=True, delivery_mode=PERSISTENT
+        exchange_name, type='topic', durable=True, delivery_mode=PERSISTENT,
+        auto_delete=True,  # undeprecated https://github.com/celery/py-amqp/issues/286
     )
 
     return exchange

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -214,7 +214,7 @@ class PollingQueueConsumer(object):
             finally:
                 if heartbeat:
                     try:
-                        self.consumer.connection.connection.heartbeat_check()
+                        self.consumer.connection.heartbeat_check()
                     except (ConnectionError, socket.error) as exc:
                         _logger.info("Heart beat failed. System will auto recover broken connection: %s", str(exc))
                         recover_connection = True

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -51,15 +51,6 @@ class ConsumeEvent(object):
             raise RuntimeError(
                 "This consumer has been stopped, and can no longer be used"
             )
-        if self.queue_consumer.connection.connected is False:
-            # we can't just reconnect here. the consumer (and its exclusive,
-            # auto-delete reply queue) must be re-established _before_ sending
-            # any request, otherwise the reply queue may not exist when the
-            # response is published.
-            raise RuntimeError(
-                "This consumer has been disconnected, and can no longer "
-                "be used"
-            )
 
         try:
             self.queue_consumer.get_message(self.correlation_id)

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -157,11 +157,11 @@ class PollingQueueConsumer(object):
     def get_message(self, correlation_id):
         start_time = time.time()
         stop_waiting = False
-        RATE = 3
+        RATE = lambda: min(2 + abs(time.time() - start_time) / self.heartbeat, self.heartbeat)
         true_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
         remaining_timeout = lambda: (
-            min(abs(start_time + self.timeout - time.time()), self.heartbeat / RATE)
-            if self.timeout is not None else self.heartbeat / RATE) if self.heartbeat else true_timeout()
+            min(abs(start_time + self.timeout - time.time()), self.heartbeat / RATE())
+            if self.timeout is not None else self.heartbeat / RATE()) if self.heartbeat else true_timeout()
         is_timed_out = lambda: abs(time.time() - start_time) > self.timeout if self.timeout is not None else False
         timed_out_err_msg = "Timeout after: {}".format(self.timeout)
 
@@ -169,7 +169,6 @@ class PollingQueueConsumer(object):
             recover_connection = False
             try:
                 if self.heartbeat:
-                    RATE = min(3 + abs(time.time() - start_time) / self.heartbeat, self.heartbeat)
                     try:
                         self.consumer.connection.heartbeat_check()
                     except (ConnectionError, socket.error) as exc:

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -53,6 +53,15 @@ class ConsumeEvent(object):
             raise RuntimeError(
                 "This consumer has been stopped, and can no longer be used"
             )
+        if self.queue_consumer.connection is None:
+            # we can't just reconnect here. the consumer (and its exclusive,
+            # auto-delete reply queue) must be re-established _before_ sending
+            # any request, otherwise the reply queue may not exist when the
+            # response is published.
+            raise RuntimeError(
+                "This consumer has been disconnected, and can no longer "
+                "be used"
+            )
 
         try:
             self.queue_consumer.get_message(self.correlation_id)

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -9,7 +9,7 @@ from kombu import Connection
 from kombu.common import maybe_declare
 from kombu.messaging import Consumer
 from nameko import serialization
-from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY, HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
+from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY, HEARTBEAT_CONFIG_KEY
 from nameko.containers import WorkerContext
 from nameko.exceptions import RpcTimeout, ConfigurationError
 from nameko.extensions import Entrypoint
@@ -121,7 +121,7 @@ class PollingQueueConsumer(object):
         amqp_uri = self.provider.container.config[AMQP_URI_CONFIG_KEY]
         ssl = self.provider.container.config.get(AMQP_SSL_CONFIG_KEY)
         self.heartbeat = self.provider.container.config.get(
-            HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
+            HEARTBEAT_CONFIG_KEY, None  # default to not enable heartbeat
         )
         if self.heartbeat is not None and self.heartbeat < 0:
             raise ConfigurationError("value for '%s' can not be negative" % HEARTBEAT_CONFIG_KEY)

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -10,7 +10,7 @@ from kombu.common import maybe_declare
 from kombu.messaging import Consumer
 
 from nameko import serialization
-from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY
+from nameko.constants import AMQP_SSL_CONFIG_KEY, AMQP_URI_CONFIG_KEY, HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
 from nameko.containers import WorkerContext
 from nameko.exceptions import RpcTimeout
 from nameko.extensions import Entrypoint
@@ -122,8 +122,10 @@ class PollingQueueConsumer(object):
 
         amqp_uri = self.provider.container.config[AMQP_URI_CONFIG_KEY]
         ssl = self.provider.container.config.get(AMQP_SSL_CONFIG_KEY)
-        _logger.debug("setup connection to broker")
-        self.connection = Connection(amqp_uri, ssl=ssl)
+        heartbeat = self.provider.container.config.get(
+            HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
+        )
+        self.connection = Connection(amqp_uri, ssl=ssl, heartbeat=heartbeat)
 
     def register_provider(self, provider):
         self.provider = provider

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -176,9 +176,7 @@ class PollingQueueConsumer(object):
                         raise
                     else:
                         _logger.debug("Heart beat OK")
-                wait_timeout = remaining_timeout()
-                _logger.debug("wait_timeout=%s", wait_timeout)
-                self.consumer.connection.drain_events(timeout=wait_timeout)
+                self.consumer.connection.drain_events(timeout=remaining_timeout())
             except socket.timeout:
                 # if socket timeout happen here, send a hearbeat and keep looping
                 # until self.timeout is reached or correlation_id is found

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -186,7 +186,8 @@ class PollingQueueConsumer(object):
                 if not is_timed_out():
                     try:  # try to recover connection if there is still time
                         recover_connection = True
-                        _logger.debug("Stabilizing connection to message broker due to connection error")
+                        _logger.debug(
+                            "Stabilizing connection to message broker due to error, {}: {}".format(exc, exc.args[0]))
                         self._setup_connection()
                         self.connection.ensure_connection(max_retries=2, timeout=true_timeout())
                         if self.connection.connected is True:

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import socket
+import time
 
 from amqp.exceptions import ConnectionError
 from kombu import Connection
@@ -80,6 +81,7 @@ class PollingQueueConsumer(object):
     the same correlation ID of the RPC-proxy call arrives.
     """
     consumer = None
+    connection = None
 
     def __init__(self, timeout=None):
         self.stopped = True
@@ -109,15 +111,27 @@ class PollingQueueConsumer(object):
         consumer.consume()
         self.consumer = consumer
 
+    def _setup_connection(self):
+        if self.connection is not None:
+            try:
+                self.connection.close()
+            except (socket.error, IOError):  # pragma: no cover
+                # If the socket has been closed, an IOError is raised, ignore
+                # it and assume the connection is already closed.
+                pass
+
+        amqp_uri = self.provider.container.config[AMQP_URI_CONFIG_KEY]
+        ssl = self.provider.container.config.get(AMQP_SSL_CONFIG_KEY)
+        _logger.debug("setup connection to broker")
+        self.connection = Connection(amqp_uri, ssl=ssl)
+
     def register_provider(self, provider):
         self.provider = provider
 
         self.serializer, self.accept = serialization.setup(
             provider.container.config)
 
-        amqp_uri = provider.container.config[AMQP_URI_CONFIG_KEY]
-        ssl = provider.container.config.get(AMQP_SSL_CONFIG_KEY)
-        self.connection = Connection(amqp_uri, ssl=ssl)
+        self._setup_connection()
 
         self.queue = provider.queue
         self._setup_consumer()
@@ -139,39 +153,79 @@ class PollingQueueConsumer(object):
         self.replies[msg_correlation_id] = (body, message)
 
     def get_message(self, correlation_id):
+        _logger.debug("waiting for message with correlation id: %s", correlation_id)
+        start_time = time.time()
+        stop_waiting = False
+        remaining_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
 
-        try:
-            while correlation_id not in self.replies:
-                self.consumer.connection.drain_events(
-                    timeout=self.timeout
-                )
+        while correlation_id not in self.replies:
+            recover_connection = False
+            try:
+                self.consumer.connection.drain_events(timeout=remaining_timeout())
 
-            body, message = self.replies.pop(correlation_id)
-            self.provider.handle_message(body, message)
+            except socket.timeout as exc:
+                recover_connection = True
 
-        except socket.timeout:
-            # TODO: this conflates an rpc timeout with a socket read timeout.
-            # a better rpc proxy implementation would recover from a socket
-            # timeout if the rpc timeout had not yet been reached
-            timeout_error = RpcTimeout(self.timeout)
-            event = self.provider._reply_events.pop(correlation_id)
-            event.send_exception(timeout_error)
+            except (socket.error, ConnectionError) as exc:
+                # in case this was a temporary error, attempt to reconnect
+                # and try again. if we fail to reconnect, the error will bubble
+                # wait till connection stable before retry
+                try:
+                    self._setup_connection()
+                    self.connection.ensure_connection(max_retries=3, timeout=remaining_timeout())
+                    if self.connection.connected is True:
+                        self._setup_consumer()
+                        self.consumer.connection.drain_events(timeout=remaining_timeout())
+                        # if timeout happen during stablizing connection then it will be treated as connection error
+                    else:
+                        err_msg = "Unable to stablizing connnection after error, {}: {}".format(exc, exc.args[0])
+                        _logger.debug(err_msg)
+                        event = self.provider._reply_events.pop(correlation_id)
+                        event.send_exception(ConnectionError(err_msg))
+                        stop_waiting = True
+                except (socket.error, ConnectionError) as exc2:
+                    err_msg = "Error during stablizing connnection, {}: {}".format(exc2, exc2.args[0])
+                    _logger.debug(err_msg)
+                    event = self.provider._reply_events.pop(correlation_id)
+                    event.send_exception(ConnectionError(err_msg))
+                    stop_waiting = True
+                else:
+                    if abs(time.time() - start_time) > self.timeout:
+                        err_msg = "Timeout during stablizing connnection after error, {}: {}".format(exc, exc.args[0])
+                        _logger.debug(err_msg)
+                        event = self.provider._reply_events.pop(correlation_id)
+                        event.send_exception(socket.timeout(err_msg))
+                        stop_waiting = True
+                        recover_connection = True
 
-            # timeout is implemented using socket timeout, so when it
-            # fires the connection is closed and must be re-established
-            self._setup_consumer()
+            except KeyboardInterrupt as exc:
+                event = self.provider._reply_events.pop(correlation_id)
+                event.send_exception(exc)
+                recover_connection = True
+                stop_waiting = True  # stop waiting
 
-        except (IOError, ConnectionError) as exc:
-            # in case this was a temporary error, attempt to reconnect
-            # and try again. if we fail to reconnect, the error will bubble
-            self._setup_consumer()
-            self.get_message(correlation_id)
-
-        except KeyboardInterrupt as exc:
-            event = self.provider._reply_events.pop(correlation_id)
-            event.send_exception(exc)
-            # exception may have killed the connection
-            self._setup_consumer()
+            finally:
+                if not stop_waiting:
+                    if correlation_id in self.replies:
+                        body, message = self.replies.pop(correlation_id)
+                        self.provider.handle_message(body, message)
+                        stop_waiting = True
+                        recover_connection = False
+                    else:
+                        if abs(time.time() - start_time) > self.timeout:
+                            err_msg = "Timeout after: {}".format(self.timeout)
+                            _logger.debug(err_msg)
+                            timeout_error = RpcTimeout(err_msg)
+                            event = self.provider._reply_events.pop(correlation_id)
+                            event.send_exception(timeout_error)
+                            stop_waiting = True
+                if recover_connection:  # alway try to recover the connection
+                    try:
+                        self._setup_consumer()
+                    except socket.error as exc:
+                        _logger.debug("Socket error during setup consumer, %s: %s", exc, exc.args[0])
+                if stop_waiting:  # stop waiting for result
+                    break
 
 
 class SingleThreadedReplyListener(ReplyListener):
@@ -184,6 +238,7 @@ class SingleThreadedReplyListener(ReplyListener):
         super(SingleThreadedReplyListener, self).__init__()
 
     def get_reply_event(self, correlation_id):
+        _logger.debug("register reply_event for correlation id: %s", correlation_id)
         reply_event = ConsumeEvent(self.queue_consumer, correlation_id)
         self._reply_events[correlation_id] = reply_event
         return reply_event

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -120,12 +120,12 @@ class PollingQueueConsumer(object):
 
         amqp_uri = self.provider.container.config[AMQP_URI_CONFIG_KEY]
         ssl = self.provider.container.config.get(AMQP_SSL_CONFIG_KEY)
-        heartbeat = self.provider.container.config.get(
+        self.heartbeat = self.provider.container.config.get(
             HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
         )
-        if heartbeat is not None and heartbeat < 0:
+        if self.heartbeat is not None and self.heartbeat < 0:
             raise ConfigurationError("value for '%s' can not be negative" % HEARTBEAT_CONFIG_KEY)
-        self.connection = Connection(amqp_uri, ssl=ssl, heartbeat=heartbeat)
+        self.connection = Connection(amqp_uri, ssl=ssl, heartbeat=self.heartbeat)
 
     def register_provider(self, provider):
         self.provider = provider
@@ -157,18 +157,26 @@ class PollingQueueConsumer(object):
     def get_message(self, correlation_id):
         start_time = time.time()
         stop_waiting = False
+        RATE = 2
+        heartbeat_interval = self.heartbeat / RATE if self.heartbeat else 0
         true_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
-        remaining_timeout = lambda: (min(abs(start_time + self.timeout - time.time()), heartbeat)
-                                     if self.timeout is not None else heartbeat) if heartbeat else true_timeout()
+        remaining_timeout = lambda: (
+            min(abs(start_time + self.timeout - time.time()), heartbeat_interval)
+            if self.timeout is not None else heartbeat_interval) if self.heartbeat else true_timeout()
         is_timed_out = lambda: abs(time.time() - start_time) > self.timeout if self.timeout is not None else False
         timed_out_err_msg = "Timeout after: {}".format(self.timeout)
-        heartbeat = self.provider.container.config.get(
-            HEARTBEAT_CONFIG_KEY, DEFAULT_HEARTBEAT
-        )
 
         while correlation_id not in self.replies:
             recover_connection = False
             try:
+                if self.heartbeat:
+                    try:
+                        self.consumer.connection.heartbeat_check()
+                    except (ConnectionError, socket.error) as exc:
+                        _logger.info("Heart beat failed. System will auto recover broken connection: %s", str(exc))
+                        raise
+                    else:
+                        _logger.debug("Heart beat OK")
                 wait_timeout = remaining_timeout()
                 _logger.debug("wait_timeout=%s", wait_timeout)
                 self.consumer.connection.drain_events(timeout=wait_timeout)
@@ -214,14 +222,6 @@ class PollingQueueConsumer(object):
                 recover_connection = True
                 stop_waiting = True
             finally:
-                if heartbeat:
-                    try:
-                        self.consumer.connection.heartbeat_check()
-                    except (ConnectionError, socket.error) as exc:
-                        _logger.info("Heart beat failed. System will auto recover broken connection: %s", str(exc))
-                        recover_connection = True
-                    else:
-                        _logger.debug("Heart beat OK")
                 if correlation_id in self.replies:
                     body, message = self.replies.pop(correlation_id)
                     self.provider.handle_message(body, message)

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -151,7 +151,8 @@ class PollingQueueConsumer(object):
         start_time = time.time()
         stop_waiting = False
         HEARTBEAT_INTERVAL = lambda: self.consumer.connection.get_heartbeat_interval()
-        RATE = lambda: min(2 + abs(time.time() - start_time) / HEARTBEAT_INTERVAL(), HEARTBEAT_INTERVAL())
+        # BASE_RATE = 2, RATE_INCREASE_SLOWDOWN = 0.75, MIN_WAIT = 3 (secs)
+        RATE = lambda: min(2 + abs(time.time() - start_time) * .75 / HEARTBEAT_INTERVAL(), HEARTBEAT_INTERVAL() / 3)
         true_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
         remaining_timeout = lambda: (
             min(abs(start_time + self.timeout - time.time()), HEARTBEAT_INTERVAL() / RATE())

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -167,7 +167,8 @@ class PollingQueueConsumer(object):
                     try:
                         self.consumer.connection.heartbeat_check()
                     except (ConnectionError, socket.error, IOError) as exc:
-                        _logger.info("Heart beat failed. System will auto recover broken connection: %s", str(exc))
+                        _logger.info("Heart beat failed. System will auto recover broken connection, %s: %s",
+                                     type(exc).__name__, exc.args[0])
                         raise
                     else:
                         _logger.debug("Heart beat OK")
@@ -188,7 +189,8 @@ class PollingQueueConsumer(object):
                     try:  # try to recover connection if there is still time
                         recover_connection = True
                         _logger.debug(
-                            "Stabilizing connection to message broker due to error, {}: {}".format(exc, exc.args[0]))
+                            "Stabilizing connection to message broker due to error, {}: {}".format(type(exc).__name__,
+                                                                                                   exc.args[0]))
                         self._setup_connection()
                         self.connection.ensure_connection(max_retries=2, timeout=true_timeout())
                         if self.connection.connected is True:
@@ -196,7 +198,8 @@ class PollingQueueConsumer(object):
                             recover_connection = False
                             # continue the loop to start send a heartbeat and wait result with this new connection
                         else:
-                            err_msg = "Unable to stabilizing connnection after error, {}: {}".format(exc, exc.args[0])
+                            err_msg = "Unable to stabilizing connnection after error, {}: {}".format(type(exc).__name__,
+                                                                                                     exc.args[0])
                             _logger.debug(err_msg)
                             event = self.provider._reply_events.pop(correlation_id)
                             event.send_exception(ConnectionError(err_msg))
@@ -206,7 +209,8 @@ class PollingQueueConsumer(object):
                         # continue the loop to try to recover connection until
                         # either self.timeout is reached or correlation_id is found
                     except (ConnectionError, socket.error) as exc2:
-                        err_msg = "Error during stabilizing connnection, {}: {}".format(exc2, exc2.args[0])
+                        err_msg = "Error during stabilizing connnection, {}: {}".format(type(exc2).__name__,
+                                                                                        exc2.args[0])
                         _logger.debug(err_msg)
                         event = self.provider._reply_events.pop(correlation_id)
                         event.send_exception(ConnectionError(err_msg))
@@ -235,7 +239,7 @@ class PollingQueueConsumer(object):
                             self._setup_connection()
                         self._setup_consumer()
                     except socket.error as exc:
-                        _logger.debug("Socket error during setup consumer, %s: %s", exc, exc.args[0])
+                        _logger.debug("Socket error during setup consumer, %s: %s", type(exc).__name__, exc.args[0])
                 if stop_waiting:  # stop waiting for result, break the loop
                     break
         else:  # other thread may have receive the message coresponding to this correlation_id before enter wait loop

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -169,7 +169,9 @@ class PollingQueueConsumer(object):
         while correlation_id not in self.replies:
             recover_connection = False
             try:
-                self.consumer.connection.drain_events(timeout=remaining_timeout())
+                wait_timeout = remaining_timeout()
+                _logger.debug("wait_timeout=%s", wait_timeout)
+                self.consumer.connection.drain_events(timeout=wait_timeout)
             except socket.timeout:
                 # if socket timeout happen here, send a hearbeat and keep looping
                 # until self.timeout is reached or correlation_id is found

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -156,13 +156,14 @@ class PollingQueueConsumer(object):
         start_time = time.time()
         stop_waiting = False
         remaining_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
+        is_timed_out = lambda: abs(time.time() - start_time) > self.timeout if self.timeout is not None else False
 
         while correlation_id not in self.replies:
             recover_connection = False
             try:
                 self.consumer.connection.drain_events(timeout=remaining_timeout())
 
-            except socket.timeout as exc:
+            except socket.timeout:  # if socket timeout happen here, keep looping until self.timeout is reached
                 recover_connection = True
 
             except (socket.error, ConnectionError) as exc:
@@ -175,8 +176,9 @@ class PollingQueueConsumer(object):
                     self.connection.ensure_connection(max_retries=3, timeout=remaining_timeout())
                     if self.connection.connected is True:
                         self._setup_consumer()
+                        # if socket.timeout happen during stablizing connection then it will be treated as
+                        # connection error and wait event loop will be stoped
                         self.consumer.connection.drain_events(timeout=remaining_timeout())
-                        # if timeout happen during stablizing connection then it will be treated as connection error
                     else:
                         err_msg = "Unable to stabilizing connnection after error, {}: {}".format(exc, exc.args[0])
                         _logger.debug(err_msg)
@@ -190,7 +192,7 @@ class PollingQueueConsumer(object):
                     event.send_exception(ConnectionError(err_msg))
                     stop_waiting = True
                 else:
-                    if abs(time.time() - start_time) > self.timeout:
+                    if is_timed_out() is True:
                         err_msg = "Timeout during stabilizing connnection after error, {}: {}".format(exc, exc.args[0])
                         _logger.debug(err_msg)
                         event = self.provider._reply_events.pop(correlation_id)
@@ -202,7 +204,7 @@ class PollingQueueConsumer(object):
                 event = self.provider._reply_events.pop(correlation_id)
                 event.send_exception(exc)
                 recover_connection = True
-                stop_waiting = True  # stop waiting
+                stop_waiting = True
 
             finally:
                 if not stop_waiting:
@@ -212,7 +214,7 @@ class PollingQueueConsumer(object):
                         stop_waiting = True
                         recover_connection = False
                     else:
-                        if abs(time.time() - start_time) > self.timeout:
+                        if is_timed_out() is True:
                             err_msg = "Timeout after: {}".format(self.timeout)
                             _logger.debug(err_msg)
                             timeout_error = RpcTimeout(err_msg)
@@ -224,9 +226,11 @@ class PollingQueueConsumer(object):
                         self._setup_consumer()
                     except socket.error as exc:
                         _logger.debug("Socket error during setup consumer, %s: %s", exc, exc.args[0])
-                if stop_waiting:  # stop waiting for result
+                if stop_waiting:  # stop waiting for result, break the loop
                     break
-
+        else:  # other thread may have receive the message coresponding to this correlation_id before enter wait loop
+            body, message = self.replies.pop(correlation_id)
+            self.provider.handle_message(body, message)
 
 class SingleThreadedReplyListener(ReplyListener):
     """ A ReplyListener which uses a custom queue consumer and ConsumeEvent.

--- a/nameko/standalone/rpc.py
+++ b/nameko/standalone/rpc.py
@@ -157,12 +157,11 @@ class PollingQueueConsumer(object):
     def get_message(self, correlation_id):
         start_time = time.time()
         stop_waiting = False
-        RATE = 2
-        heartbeat_interval = self.heartbeat / RATE if self.heartbeat else 0
+        RATE = 3
         true_timeout = lambda: abs(start_time + self.timeout - time.time()) if self.timeout is not None else None
         remaining_timeout = lambda: (
-            min(abs(start_time + self.timeout - time.time()), heartbeat_interval)
-            if self.timeout is not None else heartbeat_interval) if self.heartbeat else true_timeout()
+            min(abs(start_time + self.timeout - time.time()), self.heartbeat / RATE)
+            if self.timeout is not None else self.heartbeat / RATE) if self.heartbeat else true_timeout()
         is_timed_out = lambda: abs(time.time() - start_time) > self.timeout if self.timeout is not None else False
         timed_out_err_msg = "Timeout after: {}".format(self.timeout)
 
@@ -170,6 +169,7 @@ class PollingQueueConsumer(object):
             recover_connection = False
             try:
                 if self.heartbeat:
+                    RATE = min(3 + abs(time.time() - start_time) / self.heartbeat, self.heartbeat)
                     try:
                         self.consumer.connection.heartbeat_check()
                     except (ConnectionError, socket.error) as exc:


### PR DESCRIPTION
### Changes 1: Improve standalone RPC to be more reliable
+ Add support for heartbeat in standalone RPC
+ Auto recover connection and retry if encounter network failure (only issue which know to be recoverable)
+ Change the behavior of PollingQueueConsumer to ack message on received instead of when result() method is called (this is to match the behavior of non-standalone rpc QueueConsumer)
### Changes 2: Fix nameko shell to load correctly
+ Fix nameko shell to properly import and init ClusterRpcProxy after PYTHONSTARTUP script loaded and ShellRunner started
+ Add current working directory to System path when start nameko shell (This is to solved auto import feature of other framework such as: Django ORM)
### Changes 3: Fix compatible issue with system was running older version of nameko (prior to 2.12)
+ Add back `auto_delete=True` option when init Exchange for events to fix compatible with system was running older version of nameko. Also this feature is not deprecated from AMQP 0-9-1 anymore (see: https://github.com/celery/py-amqp/issues/286)